### PR TITLE
TFS 3068 and TFS 3070

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -137,6 +137,10 @@ limitations under the License.
         <action id="Actions.ModulePropertiesAction"
                 class="com.microsoftopentechnologies.intellij.actions.ModulePropertiesAction" text="Properties..."
                 description="Properties..." icon="/icons/small/cloudService.png"/>
+        <action id="Actions.AddRoleAction"
+                class="com.microsoftopentechnologies.intellij.actions.AddRoleAction"
+                text="Add Role..."
+                description="Add Role..." icon="/icons/RoleFolder.gif"/>
 
         <group id="AzurePopupGroup" text="Azure" description="Azure" icon="/icons/small/windowsAzure.png" popup="true"
                class="com.microsoftopentechnologies.intellij.actions.AzurePopupGroup">
@@ -145,6 +149,8 @@ limitations under the License.
             <reference ref="Actions.DeployAction"/>
             <reference ref="Actions.UnpublishAction"/>
             <reference ref="Actions.RolePropertiesAction"/>
+            <separator/>
+            <reference id="Actions.AddRoleAction"/>
             <separator/>
             <reference ref="Actions.ModulePropertiesAction"/>
         </group>

--- a/src/azure/com/microsoftopentechnologies/intellij/actions/AddRoleAction.java
+++ b/src/azure/com/microsoftopentechnologies/intellij/actions/AddRoleAction.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2015 Microsoft Open Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.microsoftopentechnologies.intellij.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.LangDataKeys;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.options.ConfigurableGroup;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import com.intellij.openapi.vfs.LocalFileSystem;
+import com.interopbridges.tools.windowsazure.WindowsAzureProjectManager;
+import com.interopbridges.tools.windowsazure.WindowsAzureRole;
+import com.microsoftopentechnologies.intellij.module.AzureModuleType;
+import com.microsoftopentechnologies.intellij.ui.azureroles.RoleConfigurablesGroup;
+import com.microsoftopentechnologies.intellij.util.PluginUtil;
+import com.microsoftopentechnologies.intellij.util.WAHelper;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.util.List;
+
+import static com.microsoftopentechnologies.intellij.ui.messages.AzureBundle.message;
+
+public class AddRoleAction extends AnAction {
+    @Override
+    public void actionPerformed(@NotNull AnActionEvent event) {
+        try {
+            // Get selected module
+            final Module module = event.getData(LangDataKeys.MODULE);
+            final String modulePath = PluginUtil.getModulePath(module);
+            WindowsAzureProjectManager waProjManager = WindowsAzureProjectManager.load(new File(modulePath));
+            List<WindowsAzureRole> listRoles = waProjManager.getRoles();
+            WindowsAzureRole windowsAzureRole = WAHelper.prepareRoleToAdd(waProjManager);
+            RoleConfigurablesGroup group = new RoleConfigurablesGroup(module, waProjManager, windowsAzureRole, true);
+            ShowSettingsUtil.getInstance().showSettingsDialog(module.getProject(), new ConfigurableGroup[]{group});
+            if (group.isModified()) { // Cancel was clicked, so changes should be reverted
+                listRoles.remove(windowsAzureRole);
+            }
+            LocalFileSystem.getInstance().findFileByPath(PluginUtil.getModulePath(module)).refresh(true, true);
+        } catch (Exception ex) {
+            PluginUtil.displayErrorDialogAndLog(message("rolsDlgErr"), message("rolsDlgErrMsg"), ex);
+        }
+    }
+
+    public void update(@NotNull AnActionEvent event) {
+        final Module module = event.getData(LangDataKeys.MODULE);
+        event.getPresentation().setEnabled(module != null && AzureModuleType.AZURE_MODULE.equals(module.getOptionValue(Module.ELEMENT_TYPE)));
+    }
+}

--- a/src/azure/com/microsoftopentechnologies/intellij/ui/JdkServerPanel.java
+++ b/src/azure/com/microsoftopentechnologies/intellij/ui/JdkServerPanel.java
@@ -1575,6 +1575,7 @@ public class JdkServerPanel {
      */
     public void srvChkBoxUnChecked() {
         setEnableServer(false);
+        applicationsTab.setEnable(false);
         setEnableDlGrpSrv(false, false);
         serverCheckBox.setEnabled(true);
     }
@@ -1617,6 +1618,7 @@ public class JdkServerPanel {
         lblSelect.setEnabled(status);
         serverUrl.setEnabled(status);
         uploadLocalServer.setEnabled(status);
+        lblSrvPath.setEnabled(status);
         serverPath.setEnabled(status);
 //        tblApp.setEnabled(status);
 //        btnAdd.setEnabled(status);
@@ -1653,10 +1655,11 @@ public class JdkServerPanel {
         serverUrl.setEnabled(status);
         lblNoteHomeDir.setEnabled(status);
         if (status && applyAutoUlParams) {
-            serverUrl.setEditable(false);
-            serverHomeDir.setEnabled(!status);
+            serverUrl.setEnabled(false);
+            serverHomeDir.setEnabled(false);
+            storageAccountServer.setEnabled(false);
         } else {
-            serverUrl.setEditable(true);
+            serverUrl.setEnabled(true);
             serverHomeDir.setEnabled(status);
         }
         if (!status) {

--- a/src/azure/com/microsoftopentechnologies/intellij/ui/azureroles/AzureRolePanel.java
+++ b/src/azure/com/microsoftopentechnologies/intellij/ui/azureroles/AzureRolePanel.java
@@ -50,12 +50,14 @@ public class AzureRolePanel extends BaseConfigurable {
     private Module module;
     private WindowsAzureProjectManager waProjManager;
     private WindowsAzureRole windowsAzureRole;
+    private boolean isNew;
 
     public AzureRolePanel(Module module, WindowsAzureProjectManager waProjManager, WindowsAzureRole windowsAzureRole, boolean isNew) {
         this.module = module;
         this.waProjManager = waProjManager;
         this.windowsAzureRole = windowsAzureRole;
         setModified(isNew);
+        this.isNew = isNew;
         init();
     }
 
@@ -311,7 +313,9 @@ public class AzureRolePanel extends BaseConfigurable {
 
     @Override
     public void reset() {
-        setModified(false);
+        if (!isNew) {
+            setModified(false);
+        }
     }
 
     @Override


### PR DESCRIPTION
TFS 3068: Add role option is missing in the context menu of azure for azure project
TFS 3070: Deploy from custom download fields should be disabled if that corresponding radio button is not selected in Server Tab
